### PR TITLE
spelling: copychildren

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function iterate(copyFrom, copyTo) {
   });
 }
 
-function copyerate(copyFrom, copyTo) {
+function copyChildren(copyFrom, copyTo) {
   if (!fs.existsSync(copyTo)) {
     fs.mkdirSync(copyTo);
   }
@@ -115,7 +115,7 @@ function deleteRecursive(path) {
     fs.rmdirSync(path);
   } else {
     iterate(startDir, endDir);
-     copyerate(moduleRoot+'/font/', endDir);
+    copyChildren(moduleRoot+'/font/', endDir);
   }
 }
 


### PR DESCRIPTION
I know that `copyerate` is a cute mash-up of `copy`+`iterate`, but it actually took me a while to figure this out.

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/a11y-css-scrubber/commit/8e231bbed18837cad514dd79fdedb2fd52cc8fe8#commitcomment-50524575

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/a11y-css-scrubber/commit/1fac985965a59030d132aabbdb3761d3c1de29c3

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

---

Additionally, I don't think there's a reason for the odd indentation of `copyerate` at the call site.